### PR TITLE
Remove client complexity

### DIFF
--- a/client.js
+++ b/client.js
@@ -11,7 +11,6 @@ module.exports = {
 
   rules: {
     'camelcase': 2,
-    'complexity': [2, 6],
     'consistent-this': [2, 'self'],
     'strict': [2, 'function']
   }


### PR DESCRIPTION
Wasn't seeing any benefit, and doing stuff like this was silly:

``` js
/*eslint complexity: [2, 26] */
```
